### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.11</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <apache.commons.collections>3.2.1</apache.commons.collections>
+        <apache.commons.collections>3.2.2</apache.commons.collections>
         <slf4j.api.version>1.7.5</slf4j.api.version>
         <slf4j.jdk14.version>1.7.5</slf4j.jdk14.version>
         <apache.maven.dependency-plugin.version>2.8</apache.maven.dependency-plugin.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
